### PR TITLE
Pin the GHC commit in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,5 +8,5 @@ extra-deps:
   - split-0.2.3.4
 ghc-options :
   "$everything": -Wall
-system-ghc: true
 allow-newer: true
+compiler: ghc-git-1370eda7a53f5dfc88afe705b2ffecb1d5544ec7-quickest


### PR DESCRIPTION
Stack can automatically build the right GHC version from source, if the commit is specified in the `stack.yaml`. Due to a Stack bug, however, this is currently blocked on https://github.com/commercialhaskell/stack/pull/5529.